### PR TITLE
Tried to switch post_gallery to a hookable filter (not works).

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -33,4 +33,5 @@ function classloader($class) {
 spl_autoload_register(__NAMESPACE__ . '\classloader');
 
 add_action('init', __NAMESPACE__ . '\Plugin::init', 20);
+add_action('init', __NAMESPACE__ . '\Plugin::post_gallery_init', 20);
 add_action('admin_init', __NAMESPACE__ . '\Admin::init');

--- a/plugin.php
+++ b/plugin.php
@@ -33,5 +33,4 @@ function classloader($class) {
 spl_autoload_register(__NAMESPACE__ . '\classloader');
 
 add_action('init', __NAMESPACE__ . '\Plugin::init', 20);
-add_action('init', __NAMESPACE__ . '\Plugin::post_gallery_init', 20);
 add_action('admin_init', __NAMESPACE__ . '\Admin::init');

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -43,7 +43,7 @@ class Plugin {
    */
   public static function init() {
     add_action('wp_enqueue_scripts', __CLASS__ . '::wp_enqueue_scripts');
-    add_filter('post_gallery', __CLASS__ . '::post_gallery', 10, 2);
+
 
     if (class_exists('WooCommerce')) {
       WooCommerce::init();
@@ -61,6 +61,16 @@ class Plugin {
 
     wp_enqueue_script('gallerya-script-libs', static::getBaseUrl() . '/dist/scripts/libs.min.js', ['jquery'], FALSE, TRUE);
     wp_enqueue_script('gallerya-script-custom', static::getBaseUrl() . '/dist/scripts/script.min.js', ['gallerya-script-libs'], FALSE, TRUE);
+  }
+
+  public static function post_gallery_init() {
+    $url = home_url(add_query_arg(array()));
+    $id = url_to_postid($url);
+    $post_type = '';
+    if (get_post_type($id) === $post_type || get_post_type() == '') {
+      add_filter('post_gallery', __CLASS__ . '::post_gallery', 10, 2);
+    }
+    return apply_filters('post_gallery_init', $post_type);
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -43,7 +43,7 @@ class Plugin {
    */
   public static function init() {
     add_action('wp_enqueue_scripts', __CLASS__ . '::wp_enqueue_scripts');
-
+    self::gallerya_post_init();
 
     if (class_exists('WooCommerce')) {
       WooCommerce::init();
@@ -63,14 +63,13 @@ class Plugin {
     wp_enqueue_script('gallerya-script-custom', static::getBaseUrl() . '/dist/scripts/script.min.js', ['gallerya-script-libs'], FALSE, TRUE);
   }
 
-  public static function post_gallery_init() {
+  public static function gallerya_post_init() {
     $url = home_url(add_query_arg(array()));
     $id = url_to_postid($url);
-    $post_type = '';
-    if (get_post_type($id) === $post_type || get_post_type() == '') {
+    $post_type = apply_filters('gallerya_post_init', 'post');
+    if (get_post_type($id) === $post_type) {
       add_filter('post_gallery', __CLASS__ . '::post_gallery', 10, 2);
     }
-    return apply_filters('post_gallery_init', $post_type);
   }
 
   /**


### PR DESCRIPTION
We could need to apply gallerya modified gallery only to certain post types. 
In order to do that I'm adding a filter that can be used for this scope. If the `$post_type` parameter is set to a specific value, gallerya will be applied only to this, otherwise will be applied at `post` types as default.