### PR TITLE
Fixed original upload being used as slider image.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 1.9.5
+  Version: 1.9.6
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/templates/layout-slider.php
+++ b/templates/layout-slider.php
@@ -2,6 +2,7 @@
 namespace Netzstrategen\Gallerya;
 
 $show_navigation = count($images) >= $nav_count_min;
+$slider_image_size = has_image_size('post-thumbnail') ? 'post-thumbnail' : 'large';
 ?>
 
 <div class="gallerya gallerya--slider">
@@ -12,7 +13,7 @@ $show_navigation = count($images) >= $nav_count_min;
       <li>
         <figure class="gallerya__image">
           <a href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-sub-html="' . esc_attr($caption) . '"' : '' ?>>
-            <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider', 'post-thumbnail')) ?>
+            <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider', $slider_image_size)) ?>
           <?php if (!empty($caption)): ?>
             <figcaption class="gallerya__image__caption"><?= $caption ?></figcaption>
           <?php endif; ?>


### PR DESCRIPTION
The 'post-thumbnail' image size is optional so the plugin was falling back to the original upload (very large).
Added check to use 'large' image size if 'post-thumbnail' doesn't exist.