### PR TITLE
Fixed gallerya slider display issues when wp-rocket plugin lazyload o…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 1.9.9
+  Version: 1.9.10
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -117,6 +117,15 @@ class Plugin {
   }
 
   /**
+   * Checks if wp-rocket plugin is active and images lazyload option is set.
+   *
+   * @return bool
+   */
+  public static function lazyLoadIsActive() {
+    return is_plugin_active('wp-rocket/wp-rocket.php') && get_rocket_option('lazyload');
+  }
+
+  /**
    * The base URL path to this plugin's folder.
    *
    * Uses plugins_url() instead of plugin_dir_url() to avoid a trailing slash.

--- a/templates/layout-grid-slider.php
+++ b/templates/layout-grid-slider.php
@@ -9,10 +9,11 @@ $group_size = 6;
     <?php foreach (array_chunk($images, $group_size) as $image_group): ?>
       <li>
         <div class="gallerya__image-group">
+        <?php $image_attr = Plugin::lazyLoadIsActive() ? ['data-no-lazy' => '1'] : []; ?>
         <?php foreach ($image_group as $image): ?>
           <figure class="gallerya__image">
             <a href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>">
-              <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_grid_slider', 'thumbnail')) ?>
+              <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_grid_slider', 'thumbnail'), FALSE, $image_attr) ?>
             </a>
           </figure>
         <?php endforeach; ?>

--- a/templates/layout-slider.php
+++ b/templates/layout-slider.php
@@ -3,31 +3,36 @@ namespace Netzstrategen\Gallerya;
 
 $show_navigation = count($images) >= $nav_count_min;
 $slider_image_size = has_image_size('post-thumbnail') ? 'post-thumbnail' : 'large';
+
+$image_attr = [];
 ?>
 
 <div class="gallerya gallerya--slider">
   <ul class="js-gallerya-slider js-gallerya-lightbox">
+    <?php $image_attr = Plugin::lazyLoadIsActive() ? ['data-no-lazy' => '1'] : []; ?>
     <?php foreach ($images as $image):
       $caption = apply_filters('gallerya/image_caption', $image->post_excerpt, $image->ID);
     ?>
       <li>
         <figure class="gallerya__image">
           <a href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-sub-html="' . esc_attr($caption) . '"' : '' ?>>
-            <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider', $slider_image_size)) ?>
+            <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider', $slider_image_size), FALSE, $image_attr) ?>
           <?php if (!empty($caption)): ?>
             <figcaption class="gallerya__image__caption"><?= $caption ?></figcaption>
           <?php endif; ?>
           </a>
         </figure>
       </li>
+      <?php $image_attr = []; ?>
     <?php endforeach; ?>
   </ul>
   <?php if ($show_navigation): ?>
     <ul class="gallerya--slider__nav  js-gallerya-thumbnail-slider">
+      <?php $image_attr = Plugin::lazyLoadIsActive() ? ['data-no-lazy' => '1'] : []; ?>
       <?php foreach ($images as $image): ?>
         <li>
           <figure class="gallerya__image">
-            <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider_thumbnail', 'thumbnail')) ?>
+            <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider_thumbnail', 'thumbnail'), FALSE, $image_attr) ?>
           </figure>
         </li>
       <?php endforeach; ?>

--- a/templates/layout-slider.php
+++ b/templates/layout-slider.php
@@ -3,20 +3,18 @@ namespace Netzstrategen\Gallerya;
 
 $show_navigation = count($images) >= $nav_count_min;
 $slider_image_size = has_image_size('post-thumbnail') ? 'post-thumbnail' : 'large';
-
-$image_attr = [];
 ?>
 
 <div class="gallerya gallerya--slider">
   <ul class="js-gallerya-slider js-gallerya-lightbox">
     <?php $image_attr = Plugin::lazyLoadIsActive() ? ['data-no-lazy' => '1'] : []; ?>
-    <?php foreach ($images as $image):
+    <?php foreach ($images as $index => $image):
       $caption = apply_filters('gallerya/image_caption', $image->post_excerpt, $image->ID);
     ?>
       <li>
         <figure class="gallerya__image">
           <a href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-sub-html="' . esc_attr($caption) . '"' : '' ?>>
-            <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider', $slider_image_size), FALSE, $image_attr) ?>
+            <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider', $slider_image_size), FALSE, !$index ?: $image_attr) ?>
           <?php if (!empty($caption)): ?>
             <figcaption class="gallerya__image__caption"><?= $caption ?></figcaption>
           <?php endif; ?>
@@ -28,7 +26,6 @@ $image_attr = [];
   </ul>
   <?php if ($show_navigation): ?>
     <ul class="gallerya--slider__nav  js-gallerya-thumbnail-slider">
-      <?php $image_attr = Plugin::lazyLoadIsActive() ? ['data-no-lazy' => '1'] : []; ?>
       <?php foreach ($images as $image): ?>
         <li>
           <figure class="gallerya__image">


### PR DESCRIPTION
…ption is set.

Gallerya sliders collapse vertically if plugin wp-rocket is in use and
configured to lazyload the images. This fixes the issue by disabling
the lazyload option for the images displayed in the gallerya slider.