### PR TITLE
Fixed Could not prevent wrong slider height when using image lazy load.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -131,10 +131,7 @@ class Plugin {
    */
   public static function isLazyLoadActive() {
     $lazyLoadIsActive = is_plugin_active('wp-rocket/wp-rocket.php') && get_rocket_option('lazyload');
-    if (has_filter('gallerya_lazyload_is_active')) {
-      $lazyLoadIsActive = apply_filters('gallerya_lazyload_is_active', $lazyLoadIsActive);
-    }
-    return $lazyLoadIsActive;
+    return apply_filters('gallerya_lazyload_is_active', $lazyLoadIsActive);
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -130,7 +130,11 @@ class Plugin {
    * @return bool
    */
   public static function isLazyLoadActive() {
-    return is_plugin_active('wp-rocket/wp-rocket.php') && get_rocket_option('lazyload');
+    $lazyLoadIsActive = is_plugin_active('wp-rocket/wp-rocket.php') && get_rocket_option('lazyload');
+    if (has_filter('gallerya_lazyload_is_active')) {
+      $lazyLoadIsActive = apply_filters('gallerya_lazyload_is_active', $lazyLoadIsActive);
+    }
+    return $lazyLoadIsActive;
   }
 
   /**


### PR DESCRIPTION
Related to task https://app.asana.com/0/383242129844224/479915789522354

Other plugins using image lazyload techniques may cause the same issues solved for wp-rocket. Adding a filter allows to prevent this in a more general and flexible way.