### PR TITLE
Gallery carousel/slider has wrong height if bj-lazy-load plugin is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "1.9.12",
+  "version": "1.10.0",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "1.10.0",
+  "version": "1.9.13",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 1.10.0
+  Version: 1.9.13
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 1.9.12
+  Version: 1.10.0
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -125,15 +125,6 @@ class Plugin {
   }
 
   /**
-   * Checks if images are being lazy loaded.
-   *
-   * @return bool
-   */
-  public static function isLazyLoadActive() {
-    return apply_filters('gallerya_lazyload_is_active', FALSE);
-  }
-
-  /**
    * Checks if the given plugin is active.
    *
    * This replicates WordPress is_plugin_active() method, which only works

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -50,7 +50,7 @@ class Plugin {
     // @todo Make lightGallery properly respect srcset & sizes in JavaScript instead
     //   of duplicating that information in HTML; see
     //   https://github.com/netzstrategen/wordpress-gallerya/pull/11#issuecomment-355664739
-    if (is_plugin_active('woocommerce/woocommerce.php')) {
+    if (static::is_plugin_active('woocommerce/woocommerce.php')) {
       add_filter('woocommerce_single_product_image_thumbnail_html', __NAMESPACE__ . '\WooCommerce::woocommerce_single_product_image_thumbnail_html', 10, 2);
     }
   }
@@ -130,7 +130,25 @@ class Plugin {
    * @return bool
    */
   public static function isLazyLoadActive() {
-    return is_plugin_active('wp-rocket/wp-rocket.php') && get_rocket_option('lazyload');
+    $lazy_load_is_active = static::is_plugin_active('wp-rocket/wp-rocket.php') && get_rocket_option('lazyload');
+    return apply_filters('gallerya_lazyload_is_active', $lazy_load_is_active);
+  }
+
+  /**
+   * Checks if the given plugin is active.
+   *
+   * This replicates WordPress is_plugin_active() method, which only works
+   * in admin pages.
+   *
+   * @see https://codex.wordpress.org/Function_Reference/is_plugin_active
+   *
+   * @param string $plugin
+   *   Relative path to plugin starting from plugins folder.
+   * @return bool
+   *   TRUE if the plugin is active.
+   */
+  public static function is_plugin_active($plugin) {
+    return in_array($plugin, (array) get_option('active_plugins', []));
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -50,7 +50,7 @@ class Plugin {
     // @todo Make lightGallery properly respect srcset & sizes in JavaScript instead
     //   of duplicating that information in HTML; see
     //   https://github.com/netzstrategen/wordpress-gallerya/pull/11#issuecomment-355664739
-    if (static::is_plugin_active('woocommerce/woocommerce.php')) {
+    if (static::isPluginActive('woocommerce/woocommerce.php')) {
       add_filter('woocommerce_single_product_image_thumbnail_html', __NAMESPACE__ . '\WooCommerce::woocommerce_single_product_image_thumbnail_html', 10, 2);
     }
   }
@@ -125,13 +125,12 @@ class Plugin {
   }
 
   /**
-   * Checks if wp-rocket plugin is active and images lazyload option is set.
+   * Checks if images are being lazy loaded.
    *
    * @return bool
    */
   public static function isLazyLoadActive() {
-    $lazy_load_is_active = static::is_plugin_active('wp-rocket/wp-rocket.php') && get_rocket_option('lazyload');
-    return apply_filters('gallerya_lazyload_is_active', $lazy_load_is_active);
+    return apply_filters('gallerya_lazyload_is_active', FALSE);
   }
 
   /**
@@ -147,7 +146,7 @@ class Plugin {
    * @return bool
    *   TRUE if the plugin is active.
    */
-  public static function is_plugin_active($plugin) {
+  public static function isPluginActive($plugin) {
     return in_array($plugin, (array) get_option('active_plugins', []));
   }
 

--- a/templates/layout-grid-slider.php
+++ b/templates/layout-grid-slider.php
@@ -2,7 +2,7 @@
 namespace Netzstrategen\Gallerya;
 
 $group_size = 6;
-$image_attr = Plugin::isLazyLoadActive() ? ['data-no-lazy' => '1'] : [];
+$image_attr = Plugin::isLazyLoadActive() ? apply_filters('gallerya_lazyload_image_attributes', ['data-no-lazy' => '1']) : [];
 ?>
 
 <div class="gallerya gallerya--slider">

--- a/templates/layout-grid-slider.php
+++ b/templates/layout-grid-slider.php
@@ -6,7 +6,7 @@ $slider_image_size = has_image_size('post-thumbnail') ? 'post-thumbnail' : 'larg
 // Prevent wrong images height calculation caused by lazy loading.
 $image_attr = apply_filters('gallerya_lazyload_image_attributes', [
   'data-no-lazy' => '1',
-  'class' => 'no-lazy attachment-large size-' . $slider_image_size,
+  'class' => "no-lazy attachment-$slider_image_size size-$slider_image_size",
 ]);
 ?>
 

--- a/templates/layout-grid-slider.php
+++ b/templates/layout-grid-slider.php
@@ -2,7 +2,11 @@
 namespace Netzstrategen\Gallerya;
 
 $group_size = 6;
-$image_attr = Plugin::isLazyLoadActive() ? apply_filters('gallerya_lazyload_image_attributes', ['data-no-lazy' => '1']) : [];
+// Prevent wrong images height calculation caused by lazy loading.
+$image_attr = apply_filters('gallerya_lazyload_image_attributes', [
+  'data-no-lazy' => '1',
+  'class' => 'no-lazy attachment-large size-large',
+]);
 ?>
 
 <div class="gallerya gallerya--slider">

--- a/templates/layout-grid-slider.php
+++ b/templates/layout-grid-slider.php
@@ -2,10 +2,11 @@
 namespace Netzstrategen\Gallerya;
 
 $group_size = 6;
+$slider_image_size = has_image_size('post-thumbnail') ? 'post-thumbnail' : 'large';
 // Prevent wrong images height calculation caused by lazy loading.
 $image_attr = apply_filters('gallerya_lazyload_image_attributes', [
   'data-no-lazy' => '1',
-  'class' => 'no-lazy attachment-large size-large',
+  'class' => 'no-lazy attachment-large size-' . $slider_image_size,
 ]);
 ?>
 

--- a/templates/layout-slider.php
+++ b/templates/layout-slider.php
@@ -3,7 +3,11 @@ namespace Netzstrategen\Gallerya;
 
 $show_navigation = count($images) >= $nav_count_min;
 $slider_image_size = has_image_size('post-thumbnail') ? 'post-thumbnail' : 'large';
-$image_attr = Plugin::isLazyLoadActive() ? apply_filters('gallerya_lazyload_image_attributes', ['data-no-lazy' => '1']) : [];
+// Prevent wrong images height calculation caused by lazy loading.
+$image_attr = apply_filters('gallerya_lazyload_image_attributes', [
+  'data-no-lazy' => '1',
+  'class' => 'no-lazy attachment-large size-large',
+]);
 ?>
 
 <div class="gallerya gallerya--slider">

--- a/templates/layout-slider.php
+++ b/templates/layout-slider.php
@@ -3,7 +3,7 @@ namespace Netzstrategen\Gallerya;
 
 $show_navigation = count($images) >= $nav_count_min;
 $slider_image_size = has_image_size('post-thumbnail') ? 'post-thumbnail' : 'large';
-$image_attr = Plugin::isLazyLoadActive() ? ['data-no-lazy' => '1'] : [];
+$image_attr = Plugin::isLazyLoadActive() ? apply_filters('gallerya_lazyload_image_attributes', ['data-no-lazy' => '1']) : [];
 ?>
 
 <div class="gallerya gallerya--slider">

--- a/templates/layout-slider.php
+++ b/templates/layout-slider.php
@@ -6,7 +6,7 @@ $slider_image_size = has_image_size('post-thumbnail') ? 'post-thumbnail' : 'larg
 // Prevent wrong images height calculation caused by lazy loading.
 $image_attr = apply_filters('gallerya_lazyload_image_attributes', [
   'data-no-lazy' => '1',
-  'class' => 'no-lazy attachment-large size-large',
+  'class' => "no-lazy attachment-$slider_image_size size-$slider_image_size",
 ]);
 ?>
 


### PR DESCRIPTION
…azy load.

Related to https://app.asana.com/0/383242129844224/580289270961121

Additional filters allows to customise lazy load plugin detection and attributes applied to gallerya images to prevent issues with image height calculation.