### PR TITLE
Fixed wrong query run when gallerya is used as a widget and a title is added to it.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -70,6 +70,10 @@ class Plugin {
    * @implements post_gallery
    */
   public static function post_gallery($output = '', $atts) {
+    // If gallerya is used as a widget, we need to remove the title from
+    // the arguments used to retrieve the posts list otherwise, the query looks
+    // for posts with name equal to the widget title.
+    unset($atts['title']);
     $atts['post_type'] = 'attachment';
     $atts['post__in'] = $atts['include'];
     $atts['orderby'] = 'post__in';


### PR DESCRIPTION
TASK: https://app.asana.com/0/387572602822932/616687796388908