### PR TITLE
Fixed 'tested up to' WordPress version in readme file.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,8 +2,8 @@
 Contributors: netzstrategen, fabianmarz, juanlopez4691, lucapipolo, tha_sun
 Tags: gallery, galleries, image, images, photo, album, responsive, responsive gallery, image gallery, photo gallery, carousel, image carousel, slider, image slider, slideshow, lightbox, fullscreen, zoom, media, foto, fotos, thumbnail, thumbnails, video, video gallery, lightgallery, flickity, jquery
 Requires at least: 4.5
-Tested up to: 4.9.8
-Stable tag: 2.1.0
+Tested up to: 5.3.2
+Stable tag: 2.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,11 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 * PHP 7.0 or later.
 
 == Changelog ==
+
+= 2.1.1 =
+2020-02-12
+
+Fixed 'tested up to' WordPress version in readme file.
 
 = 2.1.0 =
 2020-02-06

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.1.0
+  Version: 2.1.1
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen


### PR DESCRIPTION
### Task
- [Implement slider for product thumbnails](https://app.asana.com/0/30156186242982/1136103500287460/f)
### Description
- Related to my comment on the task:
> @Evelia Molina It's a pity you didn't update the Wordpress "Tested up to" version in the readme file. WordPress plugin directory shows an ugly alert saying "This plugin hasn’t been tested with the latest 3 major releases of WordPress. ...". IMO we should fix that, if possible, rising the WordPress supported version to last current one (5.3.2).