### PR TITLE
Fixed lazy loading for product thumbnails while using product variation thumbnails sliders.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -24,6 +24,11 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 
 == Changelog ==
 
+= 2.2.3 =
+2020-03-09
+
+* Fixed simple product thumbnails were not lazy loaded.
+
 = 2.2.2 =
 2020-03-04
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.2.2
+  Version: 2.2.3
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -132,8 +132,9 @@ class WooCommerce {
       ]);
     }
     else {
-      // This either has no more than one thumbnail or isn't a variable product, output default thumbnail markup.
-      echo woocommerce_get_product_thumbnail();
+      // This either has no more than one thumbnail or isn't a variable product,
+      // output default thumbnail markup.
+      woocommerce_template_loop_product_thumbnail();
     }
   }
 


### PR DESCRIPTION
### Ticket
- [Performance: Thumbnails slider in product listing pages](https://app.asana.com/0/484879736575808/1162831365220257/)

### Description
- While creating this feature, I had overseen that no filters were applied to my markup for the product thumbnails that don't need the variation thumbnails slider. This has been corrected and now the lazy loading is applied to the resulting HTML.
