### PR TITLE
Fixed variation sliders images were duplicated on product listing template.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -24,11 +24,16 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 
 == Changelog ==
 
+= 2.2.9 =
+2020-04-08
+
+* Fixed variations thumbnails were not unique on products listing pages.
+
 = 2.2.8 =
 2020-03-30
 
 * Fixed variations thumbnails retrieval to improve performance on products listing pages.
-* Bumped pugin version.
+* Bumped plugin version.
 
 = 2.2.7 =
 2020-03-24

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, fabianmarz, juanlopez4691, lucapipolo, tha_sun
 Tags: gallery, galleries, image, images, photo, album, responsive, responsive gallery, image gallery, photo gallery, carousel, image carousel, slider, image slider, slideshow, lightbox, fullscreen, zoom, media, foto, fotos, thumbnail, thumbnails, video, video gallery, lightgallery, flickity, jquery
 Requires at least: 4.5
 Tested up to: 5.3.2
-Stable tag: 2.2.8
+Stable tag: 2.2.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.2.8
+  Version: 2.2.9
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -108,14 +108,21 @@ class WooCommerce {
       // load and render all of the product variations.
       $variation_ids = $product->get_visible_children();
       $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));
-      $attachment_ids = array_unique(array_merge($attachment_ids, $wpdb->get_col($wpdb->prepare(
-        "SELECT pm.meta_value AS attachment_id
-        FROM wp_posts p
-        INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
-        WHERE p.ID IN ($placeholders)
-        ORDER BY p.menu_order ASC",
-        $variation_ids
-      ))));
+      $attachment_ids = array_unique(
+        array_merge(
+          $attachment_ids,
+          $wpdb->get_col(
+            $wpdb->prepare(
+              "SELECT pm.meta_value AS attachment_id
+              FROM wp_posts p
+              INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
+              WHERE p.ID IN ($placeholders)
+              ORDER BY p.menu_order ASC",
+              $variation_ids
+            )
+          )
+        )
+      );
     }
 
     // Only render slider if there is more than one image.

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -108,14 +108,14 @@ class WooCommerce {
       // load and render all of the product variations.
       $variation_ids = $product->get_visible_children();
       $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));
-      $attachment_ids = array_merge($attachment_ids, $wpdb->get_col($wpdb->prepare(
+      $attachment_ids = array_unique(array_merge($attachment_ids, $wpdb->get_col($wpdb->prepare(
         "SELECT pm.meta_value AS attachment_id
         FROM wp_posts p
         INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
         WHERE p.ID IN ($placeholders)
         ORDER BY p.menu_order ASC",
         $variation_ids
-      )));
+      ))));
     }
 
     // Only render slider if there is more than one image.


### PR DESCRIPTION
### Ticket
- [Fix after-update issue: first preview image for variant product is twice](https://app.asana.com/0/1162879836389371/1169578275974227)
