### PR TITLE
Fixed PHP notice thrown when retrieving thumbnails of variable product with no variations.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, fabianmarz, juanlopez4691, lucapipolo, tha_sun
 Tags: gallery, galleries, image, images, photo, album, responsive, responsive gallery, image gallery, photo gallery, carousel, image carousel, slider, image slider, slideshow, lightbox, fullscreen, zoom, media, foto, fotos, thumbnail, thumbnails, video, video gallery, lightgallery, flickity, jquery
 Requires at least: 4.5
 Tested up to: 5.4
-Stable tag: 2.7.2
+Stable tag: 2.7.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,11 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 * PHP 7.0 or later.
 
 == Changelog ==
+
+= 2.7.3 =
+2020-09-16
+
+* Fixed PHP notice thrown when retrieving thumbnails of variable product with no variations.
 
 = 2.7.2 =
 2020-09-16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.7.2
+  Version: 2.7.3
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -319,22 +319,26 @@ class WooCommerce {
       // Avoid calling $product->get_available_variations() as this would fully
       // load and render all of the product variations.
       $variation_ids = $product->get_visible_children();
-      $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));
-      $attachment_ids = array_unique(
-        array_merge(
-          $attachment_ids,
-          $wpdb->get_col(
-            $wpdb->prepare(
-              "SELECT pm.meta_value AS attachment_id
-              FROM wp_posts p
-              INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
-              WHERE p.ID IN ($placeholders)
-              ORDER BY p.menu_order ASC",
-              $variation_ids
+      $attachment_ids = [];
+
+      if (count($variation_ids)) {
+        $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));
+        $attachment_ids = array_unique(
+          array_merge(
+            $attachment_ids,
+            $wpdb->get_col(
+              $wpdb->prepare(
+                "SELECT pm.meta_value AS attachment_id
+                FROM wp_posts p
+                INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
+                WHERE p.ID IN ($placeholders)
+                ORDER BY p.menu_order ASC",
+                $variation_ids
+              )
             )
           )
-        )
-      );
+        );
+      }
     }
 
     // Only render slider if there is more than one image.


### PR DESCRIPTION
### Description
Gallery tries to retrieve the thumbnails of products variations to build a slider in product listing pages. A PHP notice is throw because the DB query is broken when the variable product has no visible variations yet.

![Screen Shot 2020-09-22 at 14 40 03](https://user-images.githubusercontent.com/13467494/93883202-89534b80-fce1-11ea-8b46-b1c71d37e57d.png)

