### PR TITLE
Fix/product variation images slider 1195999682510532 joan

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, fabianmarz, juanlopez4691, lucapipolo, tha_sun
 Tags: gallery, galleries, image, images, photo, album, responsive, responsive gallery, image gallery, photo gallery, carousel, image carousel, slider, image slider, slideshow, lightbox, fullscreen, zoom, media, foto, fotos, thumbnail, thumbnails, video, video gallery, lightgallery, flickity, jquery
 Requires at least: 4.5
 Tested up to: 5.4
-Stable tag: 2.7.3
+Stable tag: 2.7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,12 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 * PHP 7.0 or later.
 
 == Changelog ==
+
+= 2.7.4 =
+2020-09-28
+
+* Added use image alt as lightbox caption, fallback to image title.
+* Fixed product featured image was excluded from variation thumbnails slider on products listing pages.
 
 = 2.7.3 =
 2020-09-16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.7.3
+  Version: 2.7.4
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -319,7 +319,6 @@ class WooCommerce {
       // Avoid calling $product->get_available_variations() as this would fully
       // load and render all of the product variations.
       $variation_ids = $product->get_visible_children();
-      $attachment_ids = [];
 
       if (count($variation_ids)) {
         $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -127,7 +127,10 @@ class WooCommerce {
 
     $srcset = wp_get_attachment_image_srcset($thumbnail_id, 'shop_single');
     $srcsizes = wp_get_attachment_image_sizes($thumbnail_id, 'full');
-    return preg_replace('/(<a\s+)/i', '<a data-caption="' . get_the_title($thumbnail_id) . '" data-srcset="' . $srcset . '" data-sizes="' . $srcsizes . '" ', $html);
+    $image_alt = get_post_meta($thumbnail_id, '_wp_attachment_image_alt', TRUE);
+    $caption = apply_filters('gallerya/image_caption', $image_alt ?: get_the_title($thumbnail_id), $thumbnail_id);
+
+    return preg_replace('/(<a\s+)/i', '<a data-caption="' . $caption . '" data-srcset="' . $srcset . '" data-sizes="' . $srcsizes . '" ', $html);
   }
 
   /**

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -130,7 +130,7 @@ class WooCommerce {
     $image_alt = get_post_meta($thumbnail_id, '_wp_attachment_image_alt', TRUE);
     $caption = apply_filters('gallerya/image_caption', $image_alt ?: get_the_title($thumbnail_id), $thumbnail_id);
 
-    return preg_replace('/(<a\s+)/i', '<a data-caption="' . $caption . '" data-srcset="' . $srcset . '" data-sizes="' . $srcsizes . '" ', $html);
+    return preg_replace('/(<a\s+)/i', '<a data-caption="' . esc_attr($caption) . '" data-srcset="' . $srcset . '" data-sizes="' . $srcsizes . '" ', $html);
   }
 
   /**


### PR DESCRIPTION
### Ticket
- [Category pages/ overview pages/ lists: first variation image is shown instead of "featured image"](https://app.asana.com/0/809933051638353/1195999682510532)
- Image title is used as caption for lightbox slides instead of image alt attribute. Reported by @stephansperling on https://netzstrategen.slack.com/archives/CCGG11CSF/p1601285958003800?thread_ts=1601281794.002200&cid=CCGG11CSF

### Description
-
