### PR TITLE
Fixed images from inactive products variations were displayed in the gallery slider.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, fabianmarz, juanlopez4691, lucapipolo, tha_sun
 Tags: gallery, galleries, image, images, photo, album, responsive, responsive gallery, image gallery, photo gallery, carousel, image carousel, slider, image slider, slideshow, lightbox, fullscreen, zoom, media, foto, fotos, thumbnail, thumbnails, video, video gallery, lightgallery, flickity, jquery
 Requires at least: 4.5
 Tested up to: 5.4
-Stable tag: 2.7.4
+Stable tag: 2.7.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,11 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 * PHP 7.0 or later.
 
 == Changelog ==
+
+= 2.7.5 =
+2020-09-30
+
+* Fixed images from inactive products variations were displayed in the gallery slider.
 
 = 2.7.4 =
 2020-09-28

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "license": "GPL-2.0",
   "devDependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.7.4
+  Version: 2.7.5
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -250,8 +250,10 @@ class WooCommerce {
         "
         SELECT DISTINCT pm.meta_value
         FROM wp_postmeta pm
-        INNER JOIN wp_posts p ON p.ID = pm.post_id AND p.post_parent = %d
+        INNER JOIN wp_posts p ON p.ID = pm.post_id
         WHERE pm.meta_key IN ('_thumbnail_id', '_gallerya_attachment_ids')
+        AND p.post_parent = %d
+        AND p.post_status = 'publish'
         ",
         $product_id
       ))

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -250,9 +250,8 @@ class WooCommerce {
         "
         SELECT DISTINCT pm.meta_value
         FROM wp_postmeta pm
-        INNER JOIN wp_posts p ON p.ID = pm.post_id
+        INNER JOIN wp_posts p ON p.ID = pm.post_id AND p.post_parent = %d
         WHERE pm.meta_key IN ('_thumbnail_id', '_gallerya_attachment_ids')
-        AND p.post_parent = %d
         AND p.post_status = 'publish'
         ",
         $product_id


### PR DESCRIPTION
### Ticket
- [Remove images of variants that have the status "private" from galleries](https://app.asana.com/0/1156709897787098/1195999682510540)

### Description
-
