### PR TITLE
Fixed default slider image not lazy loaded.

### DIFF
--- a/templates/layout-product-variation-slider.php
+++ b/templates/layout-product-variation-slider.php
@@ -18,7 +18,9 @@ $transparent_pixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAA
             'srcset' => $transparent_pixel,
             'data-flickity-lazyload-src' => wp_get_attachment_image_url($attachment_id, $slider_image_src),
             'data-flickity-lazyload-srcset' => wp_get_attachment_image_srcset($attachment_id, $slider_image_src),
-          ] : []) ?>
+          ] : [
+            'loading' => 'lazy',
+          ]) ?>
         </figure>
       </li>
     <?php endforeach; ?>


### PR DESCRIPTION
### Ticket
- [Performance: Activate lazy loading for images of products 'below the fold'](https://app.asana.com/0/30156186242982/1199120707713925/f)

### Description
- The default thumbnail in the slider does not have any lazy loading
- Used native lazy loading as it now has >75% browser support
- This change does not touch the transparent pixel lazy loading for subsequent images in the gallery