### PR TITLE
Fixed images groups in lightbox mode.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -138,6 +138,7 @@ class Plugin {
     static::renderTemplate(['templates/layout-' . $layout . '.php'], [
       'images' => get_posts($args),
       'nav_count_min' => apply_filters('gallerya/nav_count_min', 6),
+      'group_id' => uniqid('gallerya-', TRUE),
     ]);
     $output = ob_get_clean();
     return $output;
@@ -180,7 +181,6 @@ class Plugin {
    */
   public static function renderTemplate(array $template_subpathnames, array $variables = []) {
     $template_pathname = locate_template($template_subpathnames, FALSE, FALSE);
-    $group_id = uniqid('gallerya-', true); // Used to "group" images when open.
     extract($variables, EXTR_SKIP | EXTR_REFS);
     if ($template_pathname !== '') {
       include $template_pathname;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -180,6 +180,7 @@ class Plugin {
    */
   public static function renderTemplate(array $template_subpathnames, array $variables = []) {
     $template_pathname = locate_template($template_subpathnames, FALSE, FALSE);
+    $group_id = uniqid('gallerya-', true); // Used to "group" images when open.
     extract($variables, EXTR_SKIP | EXTR_REFS);
     if ($template_pathname !== '') {
       include $template_pathname;

--- a/templates/layout-grid-slider.php
+++ b/templates/layout-grid-slider.php
@@ -19,7 +19,7 @@ $image_attr = apply_filters('gallerya_lazyload_image_attributes', [
           $caption = apply_filters('gallerya/image_caption', $image->post_excerpt, $image->ID);
         ?>
           <figure class="gallerya__image">
-            <a href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-caption="' . esc_attr($caption) . '"' : '' ?>>
+            <a data-fancybox="<?=$group_id?>" href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-caption="' . esc_attr($caption) . '"' : '' ?>>
               <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_grid_slider', 'thumbnail'), FALSE, $image_attr) ?>
             </a>
           </figure>

--- a/templates/layout-grid.php
+++ b/templates/layout-grid.php
@@ -9,7 +9,7 @@ namespace Netzstrategen\Gallerya;
     ?>
       <li>
         <figure class="gallerya__image">
-          <a href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-caption="' . esc_attr($caption) . '"' : '' ?>>
+          <a data-fancybox="<?=$group_id?>" href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-caption="' . esc_attr($caption) . '"' : '' ?>>
             <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_grid', 'medium')) ?>
           <?php if (!empty($caption)): ?>
             <figcaption class="gallerya__image__caption"><?= $caption ?></figcaption>

--- a/templates/layout-slider.php
+++ b/templates/layout-slider.php
@@ -19,7 +19,7 @@ $image_attr = apply_filters('gallerya_lazyload_image_attributes', [
     ?>
       <li>
         <figure class="gallerya__image">
-          <a href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-caption="' . esc_attr($caption) . '"' : '' ?>>
+          <a data-fancybox="<?=$group_id?>" href="<?= wp_get_attachment_image_src($image->ID, apply_filters('gallerya/image_size_lightbox', 'large'))[0] ?>" <?= !empty($caption) ? 'data-caption="' . esc_attr($caption) . '"' : '' ?>>
             <?= wp_get_attachment_image($image->ID, apply_filters('gallerya/image_size_slider', $slider_image_size), FALSE, $index ? [] : $image_attr) ?>
           <?php if (!empty($caption)): ?>
             <figcaption class="gallerya__image__caption"><?= $caption ?></figcaption>


### PR DESCRIPTION
### Ticket
- [Brand Page: Missing arrows within the lightbox gallery](https://app.asana.com/0/809933051638353/1199140993090301)

### Description
This PR fixes the images groups in lightbox mode. When clicking an image, the related ones should be accessible through the keyboard's arrows and the next/prev icons. This also fixes the thumbnails not being displayed when the relevant button is clicked in lightbox mode.

The problem is caused by a missing attribute on the `<a>` that groups the images together when in lightbox mode. It turns out that Fancybox does not support custom attributes for grouping, we're forced to use the `data-fancybox` attribute. There is [an old conversation](https://github.com/fancyapps/fancybox/issues/1632) on the plugin repo and it seems that the author is not very open to this change.