### PR TITLE
Bumped plugin version to 2.7.12.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, fabianmarz, juanlopez4691, lucapipolo, tha_sun
 Tags: gallery, galleries, image, images, photo, album, responsive, responsive gallery, image gallery, photo gallery, carousel, image carousel, slider, image slider, slideshow, lightbox, fullscreen, zoom, media, foto, fotos, thumbnail, thumbnails, video, video gallery, lightgallery, flickity, jquery
 Requires at least: 4.5
 Tested up to: 5.4
-Stable tag: 2.7.11
+Stable tag: 2.7.12
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,11 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 * PHP 7.0 or later.
 
 == Changelog ==
+
+= 2.7.12 =
+2021-04-08
+
+* Fixed images groups in lightbox mode.
 
 = 2.7.11 =
 2020-12-04

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.7.11",
+  "version": "2.7.12",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "repository": {
     "type": "git",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.7.11
+  Version: 2.7.12
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen


### PR DESCRIPTION
### Ticket
- [Brand Page: Missing arrows within the lightbox gallery](https://app.asana.com/0/809933051638353/1199140993090301)

### Description
Bumped the plugin version to 2.7.12.
