### PR TITLE
Fixed extraneous non-existing variation images in product teasers.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -342,17 +342,19 @@ class WooCommerce {
 
       if (count($variation_ids)) {
         $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));
-        $attachment_ids = array_unique(
-          array_merge(
-            $attachment_ids,
-            $wpdb->get_col(
-              $wpdb->prepare(
-                "SELECT pm.meta_value AS attachment_id
-                FROM wp_posts p
-                INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
-                WHERE p.ID IN ($placeholders)
-                ORDER BY p.menu_order ASC",
-                $variation_ids
+        $attachment_ids = array_filter(
+          array_unique(
+            array_merge(
+              $attachment_ids,
+              $wpdb->get_col(
+                $wpdb->prepare(
+                  "SELECT pm.meta_value AS attachment_id
+                  FROM wp_posts p
+                  INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
+                  WHERE p.ID IN ($placeholders)
+                  ORDER BY p.menu_order ASC",
+                  $variation_ids
+                )
               )
             )
           )

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -343,18 +343,16 @@ class WooCommerce {
       if (count($variation_ids)) {
         $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));
         $attachment_ids = array_filter(
-          array_unique(
-            array_merge(
-              $attachment_ids,
-              $wpdb->get_col(
-                $wpdb->prepare(
-                  "SELECT pm.meta_value AS attachment_id
-                  FROM wp_posts p
-                  INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
-                  WHERE p.ID IN ($placeholders)
-                  ORDER BY p.menu_order ASC",
-                  $variation_ids
-                )
+          array_merge(
+            $attachment_ids,
+            $wpdb->get_col(
+              $wpdb->prepare(
+                "SELECT DISTINCT pm.meta_value AS attachment_id
+                FROM wp_posts p
+                INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
+                WHERE p.ID IN ($placeholders)
+                ORDER BY p.menu_order ASC",
+                $variation_ids
               )
             )
           )

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -342,16 +342,18 @@ class WooCommerce {
 
       if (count($variation_ids)) {
         $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));
-        $attachment_ids = array_merge(
-          $attachment_ids,
-          $wpdb->get_col(
-            $wpdb->prepare(
-              "SELECT DISTINCT pm.meta_value AS attachment_id
-              FROM wp_posts p
-              INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
-              WHERE p.ID IN ($placeholders) AND pm.meta_value > 0
-              ORDER BY p.menu_order ASC",
-              $variation_ids
+        $attachment_ids = array_unique(
+          array_merge(
+            $attachment_ids,
+            $wpdb->get_col(
+              $wpdb->prepare(
+                "SELECT pm.meta_value AS attachment_id
+                FROM wp_posts p
+                INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
+                WHERE p.ID IN ($placeholders) AND pm.meta_value > 0
+                ORDER BY p.menu_order ASC",
+                $variation_ids
+              )
             )
           )
         );

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -342,18 +342,16 @@ class WooCommerce {
 
       if (count($variation_ids)) {
         $placeholders = implode(',', array_fill(0, count($variation_ids), '%d'));
-        $attachment_ids = array_filter(
-          array_merge(
-            $attachment_ids,
-            $wpdb->get_col(
-              $wpdb->prepare(
-                "SELECT DISTINCT pm.meta_value AS attachment_id
-                FROM wp_posts p
-                INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
-                WHERE p.ID IN ($placeholders)
-                ORDER BY p.menu_order ASC",
-                $variation_ids
-              )
+        $attachment_ids = array_merge(
+          $attachment_ids,
+          $wpdb->get_col(
+            $wpdb->prepare(
+              "SELECT DISTINCT pm.meta_value AS attachment_id
+              FROM wp_posts p
+              INNER JOIN wp_postmeta pm ON pm.post_id = p.ID AND pm.meta_key = '_thumbnail_id'
+              WHERE p.ID IN ($placeholders) AND pm.meta_value > 0
+              ORDER BY p.menu_order ASC",
+              $variation_ids
             )
           )
         );


### PR DESCRIPTION
### Ticket
- [Show arrows only when product variation have seperate images](https://app.asana.com/0/0/1200029023488130/f)

### Description
- Before and after screenshots below.
<img width="591" alt="Screen Shot 2021-04-21 at 21 05 17" src="https://user-images.githubusercontent.com/6313979/115607444-4abc5880-a2e5-11eb-9c3e-c7b320f3f806.png">
<img width="452" alt="Screen Shot 2021-04-21 at 21 04 34" src="https://user-images.githubusercontent.com/6313979/115607419-4001c380-a2e5-11eb-9cba-a31bd28c95b7.png">


