### PR TITLE
Fixed wp-release output looks as if wp-release script itself would be included in the released files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 bower_components
 .sass-cache
 unused-because-wordpress.js*
+.wp-svn

--- a/.wp-release.conf
+++ b/.wp-release.conf
@@ -17,7 +17,7 @@ SVNUSER="netzstrategen"
 # When using a folder within your plugin directory, add it to your .gitignore
 # file.
 # May exist already.  No trailing (back)slash.  Do not add /trunk.
-SVNPATH="wp-release"
+SVNPATH=".wp-svn"
 
 # Dry-run configuration.
 # When enabled (1), all actions affecting remotes (both git and svn) are


### PR DESCRIPTION
### Description
- Default for SVNPATH in .wp-release.conf was causing confusion.