### PR TITLE
Fixed backend javascript error for some product related views.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, fabianmarz, juanlopez4691, lucapipolo, tha_sun, gyo
 Tags: gallery, galleries, image, images, photo, album, responsive, responsive gallery, image gallery, photo gallery, carousel, image carousel, slider, image slider, slideshow, lightbox, fullscreen, zoom, media, foto, fotos, thumbnail, thumbnails, video, video gallery, lightgallery, flickity, jquery
 Requires at least: 4.5
 Tested up to: 5.4
-Stable tag: 2.7.13
+Stable tag: 2.7.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,10 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 * PHP 7.0 or later.
 
 == Changelog ==
+
+= 2.7.14 =
+2021-05-20
+* Fixed backend javascript error on advanced-bulk-editor plugin.
 
 = 2.7.13 =
 2021-04-28

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.7.11",
+  "version": "2.7.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.7.13",
+  "version": "2.7.14",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "repository": {
     "type": "git",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.7.13
+  Version: 2.7.14
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -18,7 +18,7 @@ $default_layout = apply_filters('gallerya/default_layout', Plugin::DEFAULT_LAYOU
 
 <script>
   jQuery(document).ready(function($) {
-    if (typeof _ !== 'function') {
+    if (typeof _ !== 'function' || typeof wp.media === 'undefined') {
       return;
     }
     _.extend(wp.media.gallery.defaults, {


### PR DESCRIPTION
### Description
- with the new version of the `advanced-bulk-editor` plugin, `gallerya`is causing on javascript error on the main backend view.
