### PR TITLE
Fixed PHP deprecated warnings due to required parameters following optional parameters.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -126,7 +126,7 @@ class Plugin {
   /**
    * @implements post_gallery
    */
-  public static function post_gallery($output = '', $atts) {
+  public static function post_gallery($output, $atts) {
     extract(shortcode_atts([
       'include' => '',
       'layout' => apply_filters('gallerya/default_layout', self::DEFAULT_LAYOUT),


### PR DESCRIPTION
Problem
```
Deprecated: Required parameter $atts follows optional parameter $output
in /wp-content/plugins/gallerya/src/Plugin.php on line 129
```
