### PR TITLE
Fixed variation slider does not load correct image if srcset is not available.

### DIFF
--- a/templates/layout-product-variation-slider.php
+++ b/templates/layout-product-variation-slider.php
@@ -10,14 +10,15 @@ $transparent_pixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAA
 
 <div class="gallerya gallerya--product-variation-slider" data-gallerya-page-dots="<?= (int) $show_page_dots ?>">
   <ul class="js-gallerya-slider">
-    <?php foreach ($attachment_ids as $index => $attachment_id): ?>
+    <?php foreach ($attachment_ids as $index => $attachment_id):
+      $slider_image_srcset = wp_get_attachment_image_srcset($attachment_id, $slider_image_src); ?>
       <li data-gallerya-variant-permalink="<?= $variation_permalinks[$index] ?>">
         <figure class="gallerya__image">
           <?= wp_get_attachment_image($attachment_id, $slider_image_src, FALSE, $index ? [
             'src' => $transparent_pixel,
-            'srcset' => $transparent_pixel,
+            'srcset' => $slider_image_srcset ? $transparent_pixel : '',
             'data-flickity-lazyload-src' => wp_get_attachment_image_url($attachment_id, $slider_image_src),
-            'data-flickity-lazyload-srcset' => wp_get_attachment_image_srcset($attachment_id, $slider_image_src),
+            'data-flickity-lazyload-srcset' => $slider_image_srcset,
           ] : [
             'loading' => 'lazy',
           ]) ?>


### PR DESCRIPTION
### Ticket
- [Bug: Missing image in image slider on product listing pages](https://app.asana.com/0/784106262441860/1202320081676613/f)

### Description
- This is happening because some images do not have the required image size (`woocommerce-thumbnail'), and the `srcset` is left with the one from the transparent pixel placeholder image. Currently investigating why the image sizes are not there, one assumption is that it might be the case for newly imported products. Still this case should be covered by the plugin.
