### PR TITLE
Added wp-graphql support for product variation additional gallery images.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.8.6",
+  "version": "2.9.0",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "repository": {
     "type": "git",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.8.6
+  Version: 2.9.0
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * Contains \Netzstrategen\Gallerya\GraphQL.
+ */
+
+namespace Netzstrategen\Gallerya;
+
+/**
+ * GraphQL integration.
+ */
+class GraphQL {
+
+  /**
+   * @implements graphql_register_types
+   */
+  public static function graphql_register_types() {
+    register_graphql_connection(
+      [
+        'fromType' => 'ProductVariation',
+        'toType' => 'MediaItem',
+        'fromFieldName' => 'galleryImages',
+        'resolve' => function ($source, array $args, $context, $info) {
+          $variation_gallery_image_ids = Woocommerce::getVariationGalleryImages($source->databaseId);
+          if (empty($variation_gallery_image_ids)) {
+            return ['nodes' => []];
+          }
+          $resolver = new \WPGraphQL\Data\Connection\PostObjectConnectionResolver($source, $args, $context, $info, 'attachment');
+          $resolver->set_query_arg('post_type', 'attachment');
+          $resolver->set_query_arg('post__in', $variation_gallery_image_ids);
+
+          // Change default ordering.
+          if (isset($resolver->get_query_args()['orderby'])) {
+            $resolver->set_query_arg('orderby', 'post__in');
+          }
+
+          return $resolver->get_connection();
+        },
+      ]
+    );
+  }
+
+}

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -7,6 +7,8 @@
 
 namespace Netzstrategen\Gallerya;
 
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
+
 /**
  * GraphQL integration.
  */
@@ -26,7 +28,7 @@ class GraphQL {
           if (empty($variation_gallery_image_ids)) {
             return ['nodes' => []];
           }
-          $resolver = new \WPGraphQL\Data\Connection\PostObjectConnectionResolver($source, $args, $context, $info, 'attachment');
+          $resolver = new PostObjectConnectionResolver($source, $args, $context, $info, 'attachment');
           $resolver->set_query_arg('post_type', 'attachment');
           $resolver->set_query_arg('post__in', $variation_gallery_image_ids);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -259,7 +259,7 @@ class Plugin {
         'fromType' => 'ProductVariation',
         'toType' => 'MediaItem',
         'fromFieldName' => 'galleryImages',
-        'resolve'       => function ($source, array $args, $context, $info) {
+        'resolve' => function ($source, array $args, $context, $info) {
           $resolver = new \WPGraphQL\Data\Connection\PostObjectConnectionResolver($source, $args, $context, $info, 'attachment');
           $resolver->set_query_arg('post_type', 'attachment');
           $resolver->set_query_arg('post__in', Woocommerce::getVariationGalleryImages($source->databaseId) ?: ['0']);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -94,11 +94,7 @@ class Plugin {
     }
 
     // Adds wp-graphql support for product variation additional gallery images.
-    if (static::isPluginActive('wp-graphql/wp-graphql.php')
-    && static::isPluginActive('wp-graphql-woocommerce/wp-graphql-woocommerce.php')
-    ) {
-      add_filter('graphql_register_types', __NAMESPACE__ . '\GraphQL::graphql_register_types');
-    }
+    add_filter('graphql_register_types', __NAMESPACE__ . '\GraphQL::graphql_register_types');
 
   }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -97,7 +97,7 @@ class Plugin {
     if (static::isPluginActive('wp-graphql/wp-graphql.php')
     && static::isPluginActive('wp-graphql-woocommerce/wp-graphql-woocommerce.php')
     ) {
-      add_filter('graphql_register_types', __CLASS__ . '::graphql_register_types');
+      add_filter('graphql_register_types', __NAMESPACE__ . '\GraphQL::graphql_register_types');
     }
 
   }
@@ -248,31 +248,6 @@ class Plugin {
    */
   public static function getBasePath() {
     return dirname(__DIR__);
-  }
-
-  /**
-   * @implements graphql_register_types
-   */
-  public static function graphql_register_types() {
-    register_graphql_connection(
-      [
-        'fromType' => 'ProductVariation',
-        'toType' => 'MediaItem',
-        'fromFieldName' => 'galleryImages',
-        'resolve' => function ($source, array $args, $context, $info) {
-          $resolver = new \WPGraphQL\Data\Connection\PostObjectConnectionResolver($source, $args, $context, $info, 'attachment');
-          $resolver->set_query_arg('post_type', 'attachment');
-          $resolver->set_query_arg('post__in', Woocommerce::getVariationGalleryImages($source->databaseId) ?: ['0']);
-
-          // Change default ordering.
-          if (!in_array('orderby', array_keys($resolver->get_query_args()), TRUE)) {
-            $resolver->set_query_arg('orderby', 'post__in');
-          }
-
-          return $resolver->get_connection();
-        },
-      ]
-    );
   }
 
 }


### PR DESCRIPTION
### Ticket
https://app.asana.com/0/1200447348065174/1202659778651598/f

This PR adds a connection between the object types: `ProductVariation` & `MediaItem`, resulting in adding a new node called `galleryImages` that resolves using the product variation gallery image ids stored by gallerya.

Resources:
Current fields: https://github.com/wp-graphql/wp-graphql-woocommerce/blob/develop/includes/type/object/class-product-variation-type.php
A similar connection done for the simple and variable product types: https://github.com/wp-graphql/wp-graphql-woocommerce/blob/312e9ce978f8a61ff546016962b2d093b3cf4d00/includes/connection/class-posts.php
How to add a wp-graphql connection: https://www.wpgraphql.com/recipes/register-connection-to-attached-media/

![image](https://user-images.githubusercontent.com/18492002/185961135-20f1d55f-4af9-4667-ba98-e7cb41aa9780.png)
