### PR TITLE
Fixed wrong return statement in graphql edges and class name.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, fabianmarz, juanlopez4691, lucapipolo, tha_sun, gyo
 Tags: gallery, image gallery, video gallery, carousel, lightbox, slider, responsive gallery, image slider, lightgallery, flickity
 Requires at least: 4.5
 Tested up to: 6.0
-Stable tag: 2.9.0
+Stable tag: 2.9.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,11 @@ Gallerya transforms the WordPress native post gallery into a full fledged slides
 * PHP 7.0 or later.
 
 == Changelog ==
+
+= 2.9.1 =
+2023-02-23
+
+* Fix wp-graphql support incorrect return statament edges.
 
 = 2.9.0 =
 2022-09-14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gallerya",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "netzstrategen <hallo@netzstrategen.com>",
   "repository": {
     "type": "git",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Gallerya
-  Version: 2.9.0
+  Version: 2.9.1
   Text Domain: gallerya
   Description: Change the native post gallery to be displayed as a slider with lightbox support.
   Author: netzstrategen

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -24,9 +24,9 @@ class GraphQL {
         'toType' => 'MediaItem',
         'fromFieldName' => 'galleryImages',
         'resolve' => function ($source, array $args, $context, $info) {
-          $variation_gallery_image_ids = Woocommerce::getVariationGalleryImages($source->databaseId);
+          $variation_gallery_image_ids = WooCommerce::getVariationGalleryImages($source->databaseId);
           if (empty($variation_gallery_image_ids)) {
-            return ['nodes' => []];
+            return;
           }
           $resolver = new PostObjectConnectionResolver($source, $args, $context, $info, 'attachment');
           $resolver->set_query_arg('post_type', 'attachment');


### PR DESCRIPTION
### Description
Fixes wrong return statement when using edges in wp-graphl.
Fixes calling the wrong class name.
